### PR TITLE
Added TS-212P to string list

### DIFF
--- a/pages/debian/kirkwood/qnap/ts-219/recovery.md
+++ b/pages/debian/kirkwood/qnap/ts-219/recovery.md
@@ -150,6 +150,11 @@ You can check the following table to find out which string to use:
 </tr>
 
 <tr>
+<td>TS-212P</td>
+<td>`F_TS-212P`</td>
+</tr>
+
+<tr>
 <td>TS-219</td>
 <td>`F_TS-219`</td>
 </tr>


### PR DESCRIPTION
TS-212P is missing in the list. I tried several possibilities and it looks that 'F_TS-212P' is correct filename.